### PR TITLE
fix: 🐛 back navigating in version steps and sidebar metadata pages

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -17,7 +17,7 @@ const themeOverrides: GlobalThemeOverrides = {
 
 router.beforeEach((to, from) => {
   if (typeof from.name !== "string") return;
-  prev_route.value = from;
+  prev_route.value = !to.query?._clear ? from : null;
   current_route.value = to;
 });
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import type { GlobalThemeOverrides } from "naive-ui";
 import { materialTheme, Notifications, Notivue } from "notivue";
+import { useRouter } from "vue-router";
 
+import { current_route, prev_route } from "@/stores/nav";
 import { theme } from "@/stores/settings";
 
+const router = useRouter();
 const themeOverrides: GlobalThemeOverrides = {
   Button: {},
   Form: {
@@ -11,6 +14,12 @@ const themeOverrides: GlobalThemeOverrides = {
     labelFontWeight: "600",
   },
 };
+
+router.beforeEach((to, from) => {
+  if (typeof from.name !== "string") return;
+  prev_route.value = from;
+  current_route.value = to;
+});
 </script>
 
 <template>

--- a/src/components/sidebar/AppSidebar.vue
+++ b/src/components/sidebar/AppSidebar.vue
@@ -305,12 +305,14 @@ const toggleSidebar = (collapsed: boolean) => {
 
 const navigateTo = (value: string) => {
   const routeName = value.split(":")[0];
-
   if (routeName === "studies") {
     sidebarStore.setAppSidebarCollapsed(false);
 
     router.push({
       name: value,
+      query: {
+        _clear: "true",
+      },
     });
 
     return;
@@ -318,11 +320,13 @@ const navigateTo = (value: string) => {
 
   if (routeName === "study") {
     sidebarStore.setAppSidebarCollapsed(false);
-
     router.push({
       name: value,
       params: {
         studyId: studyID.value,
+      },
+      query: {
+        _clear: "true",
       },
     });
 
@@ -336,6 +340,9 @@ const navigateTo = (value: string) => {
       name: value,
       params: {
         studyId: studyID.value,
+      },
+      query: {
+        _clear: "true",
       },
     });
 
@@ -372,8 +379,6 @@ const defaultExpandedKeys = computed(() => {
 
   if (currentRoute.name) {
     const name = currentRoute.name as string;
-
-    console.log("appsidebar-name", name, name.startsWith("study:metadata"));
 
     if (name.startsWith("study:metadata")) {
       return ["study:metadata"];

--- a/src/components/sidebar/AppSidebar.vue
+++ b/src/components/sidebar/AppSidebar.vue
@@ -390,7 +390,7 @@ const selectAndExpand = (key: string) => {
   menuInstRef.value?.showOption(key);
 };
 
-router.beforeEach((to, from) => {
+router.beforeEach((to) => {
   if (typeof to.name !== "string") return;
   const name: string = to.meta && to.meta.menuItem ? (to.meta.menuItem as string) : to.name;
   selectAndExpand(name);

--- a/src/components/sidebar/DatasetSidebar.vue
+++ b/src/components/sidebar/DatasetSidebar.vue
@@ -163,6 +163,9 @@ const navigateTo = (value: string) => {
         datasetId: datasetId.value,
         studyId: studyID.value,
       },
+      query: {
+        _clear: "true",
+      },
     });
 
     return;

--- a/src/components/sidebar/DatasetSidebar.vue
+++ b/src/components/sidebar/DatasetSidebar.vue
@@ -206,7 +206,7 @@ const selectAndExpand = (key: string) => {
   menuInstRef.value?.showOption(key);
 };
 
-router.beforeEach((to, from) => {
+router.beforeEach((to) => {
   if (typeof to.name !== "string") return;
   const name: string = to.meta && to.meta.menuItem ? (to.meta.menuItem as string) : to.name;
   selectAndExpand(name);

--- a/src/stores/nav.ts
+++ b/src/stores/nav.ts
@@ -1,0 +1,36 @@
+import type { Ref } from "vue/dist/vue";
+import type { RouteLocationNormalized } from "vue-router";
+
+export const prev_route: Ref<RouteLocationNormalized | null | undefined> = ref(null);
+export const current_route: Ref<RouteLocationNormalized | null | undefined> = ref(null);
+
+export function getBackRoute(): string {
+  console.log(prev_route.value);
+  if (prev_route.value && typeof prev_route.value.name == "string") {
+    if (prev_route.value.name == "dataset:publish:version:study-metadata") {
+      return "dataset:publish:version:study-metadata";
+    }
+    if (prev_route.value.name == "dataset:publish:version:dataset-metadata") {
+      return "dataset:publish:version:dataset-metadata";
+    }
+    if (prev_route.value.name.startsWith("dataset:")) {
+      return "dataset:overview";
+    }
+    if (prev_route.value.name.startsWith("study:")) {
+      return "study:overview";
+    }
+  }
+  return "studies:all-studies";
+}
+
+export function getBackParams(): object {
+  if (prev_route.value && typeof prev_route.value.name == "string") {
+    if (prev_route.value.name == "dataset:publish:version:study-metadata") {
+      return prev_route.value?.params;
+    }
+    if (prev_route.value.name == "dataset:publish:version:dataset-metadata") {
+      return prev_route.value?.params;
+    }
+  }
+  return prev_route.value ? prev_route.value.params : {};
+}

--- a/src/stores/nav.ts
+++ b/src/stores/nav.ts
@@ -5,7 +5,6 @@ export const prev_route: Ref<RouteLocationNormalized | null | undefined> = ref(n
 export const current_route: Ref<RouteLocationNormalized | null | undefined> = ref(null);
 
 export function getBackRoute(): string {
-  console.log(prev_route.value);
   if (prev_route.value && typeof prev_route.value.name == "string") {
     if (prev_route.value.name == "dataset:publish:version:study-metadata") {
       return "dataset:publish:version:study-metadata";
@@ -20,7 +19,16 @@ export function getBackRoute(): string {
       return "study:overview";
     }
   }
-  return "studies:all-studies";
+  if (current_route.value && typeof current_route.value.name == "string") {
+    if (current_route.value.name.startsWith("dataset")) {
+      return "dataset:overview";
+    }
+    if (current_route.value.name.startsWith("study")) {
+      console.log("oh no were here");
+      return "study:overview";
+    }
+  }
+  return "study:overview";
 }
 
 export function getBackParams(): object {
@@ -32,5 +40,13 @@ export function getBackParams(): object {
       return prev_route.value?.params;
     }
   }
-  return prev_route.value ? prev_route.value.params : {};
+  if (current_route.value && typeof current_route.value.name == "string") {
+    if (current_route.value.name.startsWith("dataset")) {
+      return current_route.value?.params;
+    }
+    if (current_route.value.name.startsWith("study")) {
+      return current_route.value?.params;
+    }
+  }
+  return current_route.value ? current_route.value.params : {};
 }

--- a/src/types/Version.d.ts
+++ b/src/types/Version.d.ts
@@ -41,6 +41,7 @@ export interface VersionStudyOverallOfficial {
   id: string;
   name: string;
   affiliation: string;
+  role: string;
 }
 
 export interface VersionDesign {
@@ -103,7 +104,8 @@ export interface VersionStudyStatusModule {
 }
 
 export interface VersionStudySponsor {
-  responsible_party_investigator_name: string;
+  lead_sponsor_name: string;
+  responsible_party_investigator_name: string | null;
   responsible_party_type: string;
 }
 
@@ -125,7 +127,6 @@ export interface VersionStudyArm {
 export interface VersionStudyEligibility {
   gender: string | null;
   gender_based: string | null;
-  maximum_age_value: number | null;
   minimum_age_value: number | null;
 }
 
@@ -233,7 +234,7 @@ export interface VersionDatasetSubjects {
 export interface VersionDatasetAccess {
   description: string;
   type: string | null;
-  url: string;
+  url: string | null;
   url_last_checked: number | null;
 }
 
@@ -246,7 +247,7 @@ export interface VersionDatasetRights {
 export interface VersionDatasetFunders {
   id: string;
   name: string;
-  award_number: string;
+  award_number: string | null;
   identifier: string;
 }
 

--- a/src/views/study/dataset/metadata/about/DatasetMetadataOther.vue
+++ b/src/views/study/dataset/metadata/about/DatasetMetadataOther.vue
@@ -2,9 +2,10 @@
 import type { FormInst } from "naive-ui";
 
 import LANGUAGES_JSON from "@/assets/data/languages.json";
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { DatasetOther } from "@/types/Dataset";
 import { baseURL } from "@/utils/constants";
-const router = useRouter();
+
 const route = useRoute();
 const push = usePush();
 
@@ -119,7 +120,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Additional Metadata"
       description="Some metadata that didn't really fit in other sections."
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/about/DatasetMetadataOther.vue
+++ b/src/views/study/dataset/metadata/about/DatasetMetadataOther.vue
@@ -4,7 +4,7 @@ import type { FormInst } from "naive-ui";
 import LANGUAGES_JSON from "@/assets/data/languages.json";
 import type { DatasetOther } from "@/types/Dataset";
 import { baseURL } from "@/utils/constants";
-
+const router = useRouter();
 const route = useRoute();
 const push = usePush();
 
@@ -119,10 +119,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Additional Metadata"
       description="Some metadata that didn't really fit in other sections."
-      linkName="study:overview"
-      :linkParams="{
-        studyId: route.params.studyId,
-      }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/access/DatasetMetadataAccess.vue
+++ b/src/views/study/dataset/metadata/access/DatasetMetadataAccess.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { FormInst } from "naive-ui";
+import { useRouter } from "vue-router";
 
 import FORM_JSON from "@/assets/data/form.json";
 import type { DatasetAccess } from "@/types/Dataset";
@@ -7,6 +8,8 @@ import { baseURL } from "@/utils/constants";
 
 const route = useRoute();
 const push = usePush();
+
+const router = useRouter();
 
 const routeParams = {
   datasetId: route.params.datasetId as string,
@@ -102,10 +105,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Access Details"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      linkName="study:overview"
-      :linkParams="{
-        studyId: route.params.studyId,
-      }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/access/DatasetMetadataAccess.vue
+++ b/src/views/study/dataset/metadata/access/DatasetMetadataAccess.vue
@@ -1,15 +1,12 @@
 <script setup lang="ts">
-import type { FormInst } from "naive-ui";
-import { useRouter } from "vue-router";
+import type { FormInst, FormRules } from "naive-ui";
 
 import FORM_JSON from "@/assets/data/form.json";
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { DatasetAccess } from "@/types/Dataset";
 import { baseURL } from "@/utils/constants";
-
 const route = useRoute();
 const push = usePush();
-
-const router = useRouter();
 
 const routeParams = {
   datasetId: route.params.datasetId as string,
@@ -105,7 +102,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Access Details"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/consent/DatasetMetadataConsent.vue
+++ b/src/views/study/dataset/metadata/consent/DatasetMetadataConsent.vue
@@ -4,7 +4,7 @@ import type { FormInst } from "naive-ui";
 import FORM_JSON from "@/assets/data/form.json";
 import type { DatasetConsent } from "@/types/Dataset";
 import { baseURL } from "@/utils/constants";
-
+const router = useRouter();
 const route = useRoute();
 const push = usePush();
 
@@ -113,10 +113,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Consent"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      linkName="study:overview"
-      :linkParams="{
-        studyId: route.params.studyId,
-      }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/consent/DatasetMetadataConsent.vue
+++ b/src/views/study/dataset/metadata/consent/DatasetMetadataConsent.vue
@@ -2,9 +2,9 @@
 import type { FormInst } from "naive-ui";
 
 import FORM_JSON from "@/assets/data/form.json";
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { DatasetConsent } from "@/types/Dataset";
 import { baseURL } from "@/utils/constants";
-const router = useRouter();
 const route = useRoute();
 const push = usePush();
 
@@ -113,7 +113,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Consent"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/contributors/DatasetMetadataContributors.vue
+++ b/src/views/study/dataset/metadata/contributors/DatasetMetadataContributors.vue
@@ -164,8 +164,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Contributors"
       description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      linkName="dataset:overview"
-      :linkParams="{ studyId: routeParams.studyId, datasetId: routeParams.datasetId }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/contributors/DatasetMetadataContributors.vue
+++ b/src/views/study/dataset/metadata/contributors/DatasetMetadataContributors.vue
@@ -3,6 +3,7 @@ import type { FormInst } from "naive-ui";
 import { nanoid } from "nanoid";
 
 import FORM_JSON from "@/assets/data/form.json";
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { DatasetContributors } from "@/types/Dataset";
 import { baseURL } from "@/utils/constants";
 
@@ -164,7 +165,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Contributors"
       description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/creators/DatasetMetadataCreator.vue
+++ b/src/views/study/dataset/metadata/creators/DatasetMetadataCreator.vue
@@ -3,6 +3,7 @@ import type { FormInst } from "naive-ui";
 import { nanoid } from "nanoid";
 
 import FORM_JSON from "@/assets/data/form.json";
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { DatasetCreators } from "@/types/Dataset";
 import { baseURL } from "@/utils/constants";
 
@@ -162,7 +163,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Creators"
       description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/creators/DatasetMetadataCreator.vue
+++ b/src/views/study/dataset/metadata/creators/DatasetMetadataCreator.vue
@@ -162,8 +162,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Creators"
       description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      linkName="dataset:overview"
-      :linkParams="{ studyId: routeParams.studyId, datasetId: routeParams.datasetId }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/dates/DatasetMetadataDates.vue
+++ b/src/views/study/dataset/metadata/dates/DatasetMetadataDates.vue
@@ -3,6 +3,7 @@ import type { FormInst } from "naive-ui";
 import { nanoid } from "nanoid";
 
 import FORM_JSON from "@/assets/data/form.json";
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { DatasetDates } from "@/types/Dataset";
 import { baseURL } from "@/utils/constants";
 
@@ -134,7 +135,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Dates"
       description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/dates/DatasetMetadataDates.vue
+++ b/src/views/study/dataset/metadata/dates/DatasetMetadataDates.vue
@@ -134,8 +134,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Dates"
       description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      linkName="dataset:overview"
-      :linkParams="{ studyId: routeParams.studyId, datasetId: routeParams.datasetId }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/deidentification/DatasetMetadataDeIdentification.vue
+++ b/src/views/study/dataset/metadata/deidentification/DatasetMetadataDeIdentification.vue
@@ -4,7 +4,7 @@ import type { FormInst } from "naive-ui";
 import FORM_JSON from "@/assets/data/form.json";
 import type { DatasetDeIdentLevel } from "@/types/Dataset";
 import { baseURL } from "@/utils/constants";
-
+const router = useRouter();
 const route = useRoute();
 const push = usePush();
 
@@ -113,10 +113,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="De-identification Levels"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      linkName="study:overview"
-      :linkParams="{
-        studyId: route.params.studyId,
-      }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/deidentification/DatasetMetadataDeIdentification.vue
+++ b/src/views/study/dataset/metadata/deidentification/DatasetMetadataDeIdentification.vue
@@ -2,9 +2,9 @@
 import type { FormInst } from "naive-ui";
 
 import FORM_JSON from "@/assets/data/form.json";
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { DatasetDeIdentLevel } from "@/types/Dataset";
 import { baseURL } from "@/utils/constants";
-const router = useRouter();
 const route = useRoute();
 const push = usePush();
 
@@ -113,7 +113,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="De-identification Levels"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/descriptions/DatasetMetadataDescriptions.vue
+++ b/src/views/study/dataset/metadata/descriptions/DatasetMetadataDescriptions.vue
@@ -148,8 +148,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Descriptions"
       description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      linkName="dataset:overview"
-      :linkParams="{ studyId: routeParams.studyId, datasetId: routeParams.datasetId }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/descriptions/DatasetMetadataDescriptions.vue
+++ b/src/views/study/dataset/metadata/descriptions/DatasetMetadataDescriptions.vue
@@ -2,6 +2,7 @@
 import { nanoid } from "nanoid";
 
 import FORM_JSON from "@/assets/data/form.json";
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { DatasetDescriptions } from "@/types/Dataset";
 import { baseURL } from "@/utils/constants";
 
@@ -148,7 +149,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Descriptions"
       description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/funders/DatasetMetadataFunders.vue
+++ b/src/views/study/dataset/metadata/funders/DatasetMetadataFunders.vue
@@ -3,6 +3,7 @@ import type { FormInst } from "naive-ui";
 import { nanoid } from "nanoid";
 
 import FORM_JSON from "@/assets/data/form.json";
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { DatasetFunders } from "@/types/Dataset";
 import { baseURL } from "@/utils/constants";
 
@@ -142,7 +143,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Funders"
       description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/funders/DatasetMetadataFunders.vue
+++ b/src/views/study/dataset/metadata/funders/DatasetMetadataFunders.vue
@@ -142,8 +142,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Funders"
       description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      linkName="dataset:overview"
-      :linkParams="{ studyId: routeParams.studyId, datasetId: routeParams.datasetId }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/identifiers/DatasetMetadataIdentifiers.vue
+++ b/src/views/study/dataset/metadata/identifiers/DatasetMetadataIdentifiers.vue
@@ -2,6 +2,7 @@
 import { nanoid } from "nanoid";
 
 import FORM_JSON from "@/assets/data/form.json";
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { DatasetIdentifiers } from "@/types/Dataset";
 import { baseURL } from "@/utils/constants";
 
@@ -150,7 +151,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Identifiers"
       description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/identifiers/DatasetMetadataIdentifiers.vue
+++ b/src/views/study/dataset/metadata/identifiers/DatasetMetadataIdentifiers.vue
@@ -150,8 +150,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Identifiers"
       description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      linkName="dataset:overview"
-      :linkParams="{ studyId: routeParams.studyId, datasetId: routeParams.datasetId }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/keys/DatasetMetadataRecordKeys.vue
+++ b/src/views/study/dataset/metadata/keys/DatasetMetadataRecordKeys.vue
@@ -4,7 +4,7 @@ import type { FormInst } from "naive-ui";
 import FORM_JSON from "@/assets/data/form.json";
 import type { DatasetRecordKeys } from "@/types/Dataset";
 import { baseURL } from "@/utils/constants";
-
+const router = useRouter();
 const route = useRoute();
 const push = usePush();
 
@@ -98,10 +98,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Record Keys"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      linkName="study:overview"
-      :linkParams="{
-        studyId: route.params.studyId,
-      }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/keys/DatasetMetadataRecordKeys.vue
+++ b/src/views/study/dataset/metadata/keys/DatasetMetadataRecordKeys.vue
@@ -2,9 +2,9 @@
 import type { FormInst } from "naive-ui";
 
 import FORM_JSON from "@/assets/data/form.json";
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { DatasetRecordKeys } from "@/types/Dataset";
 import { baseURL } from "@/utils/constants";
-const router = useRouter();
 const route = useRoute();
 const push = usePush();
 
@@ -98,7 +98,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Record Keys"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/publisher/DatasetMetadataPublisher.vue
+++ b/src/views/study/dataset/metadata/publisher/DatasetMetadataPublisher.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import type { FormInst } from "naive-ui";
 
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { DatasetPublisher } from "@/types/Dataset";
 import { baseURL } from "@/utils/constants";
-const router = useRouter();
 const route = useRoute();
 const push = usePush();
 
@@ -102,7 +102,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Publisher"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/publisher/DatasetMetadataPublisher.vue
+++ b/src/views/study/dataset/metadata/publisher/DatasetMetadataPublisher.vue
@@ -3,7 +3,7 @@ import type { FormInst } from "naive-ui";
 
 import type { DatasetPublisher } from "@/types/Dataset";
 import { baseURL } from "@/utils/constants";
-
+const router = useRouter();
 const route = useRoute();
 const push = usePush();
 
@@ -102,10 +102,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Publisher"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      linkName="study:overview"
-      :linkParams="{
-        studyId: route.params.studyId,
-      }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/related/DatasetMetadataRelatedItems.vue
+++ b/src/views/study/dataset/metadata/related/DatasetMetadataRelatedItems.vue
@@ -416,8 +416,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Related Items"
       description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      linkName="dataset:overview"
-      :linkParams="{ studyId: routeParams.studyId, datasetId: routeParams.datasetId }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/related/DatasetMetadataRelatedItems.vue
+++ b/src/views/study/dataset/metadata/related/DatasetMetadataRelatedItems.vue
@@ -2,6 +2,7 @@
 import { nanoid } from "nanoid";
 
 import FORM_JSON from "@/assets/data/form.json";
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { DatasetRelatedItems } from "@/types/Dataset";
 import { baseURL } from "@/utils/constants";
 
@@ -416,7 +417,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Related Items"
       description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/rights/DatasetMetadataRights.vue
+++ b/src/views/study/dataset/metadata/rights/DatasetMetadataRights.vue
@@ -2,6 +2,7 @@
 import type { FormInst } from "naive-ui";
 import { nanoid } from "nanoid";
 
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { DatasetRights } from "@/types/Dataset";
 import { baseURL } from "@/utils/constants";
 
@@ -135,7 +136,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Rights"
       description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/rights/DatasetMetadataRights.vue
+++ b/src/views/study/dataset/metadata/rights/DatasetMetadataRights.vue
@@ -135,8 +135,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Rights"
       description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      linkName="dataset:overview"
-      :linkParams="{ studyId: routeParams.studyId, datasetId: routeParams.datasetId }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/subjects/DatasetMetadataSubjects.vue
+++ b/src/views/study/dataset/metadata/subjects/DatasetMetadataSubjects.vue
@@ -140,8 +140,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Subjects"
       description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      linkName="dataset:overview"
-      :linkParams="{ studyId: routeParams.studyId, datasetId: routeParams.datasetId }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/subjects/DatasetMetadataSubjects.vue
+++ b/src/views/study/dataset/metadata/subjects/DatasetMetadataSubjects.vue
@@ -2,6 +2,7 @@
 import type { FormInst } from "naive-ui";
 import { nanoid } from "nanoid";
 
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { DatasetSubjects } from "@/types/Dataset";
 import { baseURL } from "@/utils/constants";
 
@@ -140,7 +141,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Subjects"
       description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/title/DatasetMetadataTitle.vue
+++ b/src/views/study/dataset/metadata/title/DatasetMetadataTitle.vue
@@ -146,8 +146,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Titles"
       description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      linkName="dataset:overview"
-      :linkParams="{ studyId: routeParams.studyId, datasetId: routeParams.datasetId }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/dataset/metadata/title/DatasetMetadataTitle.vue
+++ b/src/views/study/dataset/metadata/title/DatasetMetadataTitle.vue
@@ -4,6 +4,7 @@ import { nanoid } from "nanoid";
 import FORM_JSON from "@/assets/data/form.json";
 import LottieLoader from "@/components/loader/LottieLoader.vue";
 import FadeTransition from "@/components/transitions/FadeTransition.vue";
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { DatasetTitles } from "@/types/Dataset";
 import { baseURL } from "@/utils/constants";
 
@@ -146,7 +147,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Titles"
       description="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/dataset/publish/metadata/PublishDatasetMetadata.vue
+++ b/src/views/study/dataset/publish/metadata/PublishDatasetMetadata.vue
@@ -424,12 +424,12 @@ function handleNextButton() {
               ? "Yes"
               : dataset_metadata.de_identification.direct === false
               ? "No"
-              : "-"
+              : ""
           }}
         </n-descriptions-item>
 
         <n-descriptions-item label="Type">
-          {{ dataset_metadata.de_identification.type || "-" }}
+          {{ dataset_metadata.de_identification.type }}
         </n-descriptions-item>
       </n-descriptions>
 

--- a/src/views/study/dataset/publish/metadata/PublishDatasetMetadata.vue
+++ b/src/views/study/dataset/publish/metadata/PublishDatasetMetadata.vue
@@ -330,38 +330,42 @@ function handleNextButton() {
     </CollapsibleCard>
 
     <CollapsibleCard title="Publisher" bordered>
-      <n-table :bordered="true" striped :single-line="false">
-        <thead>
-          <tr>
-            <th>Publisher</th>
+      <!--      <n-table-->
+      <!--        :bordered="true"-->
+      <!--        striped-->
+      <!--        :single-line="false"-->
+      <!--        :v-if="dataset_metadata.publisher.publisher"-->
+      <!--      >-->
+      <!--        <tbody>-->
+      <!--          <tr>-->
+      <!--            <th>Publisher</th>-->
 
-            <th>Organization name</th>
-          </tr>
-        </thead>
+      <!--            <td v-if="dataset_metadata.publisher.publisher">-->
+      <!--              {{ dataset_metadata.publisher.publisher }}-->
+      <!--            </td>-->
+      <!--          </tr>-->
+      <!--        </tbody>-->
+      <!--      </n-table>-->
 
-        <tbody>
-          <tr>
-            <td v-if="dataset_metadata.publisher.publisher">
-              {{ dataset_metadata.publisher.managing_organization_name }}
-            </td>
+      <div
+        v-if="dataset_metadata.publisher && dataset_metadata.publisher.publisher"
+        class="border border-gray-100 p-3"
+      >
+        {{ dataset_metadata.publisher.publisher }}
+      </div>
 
-            <td v-if="dataset_metadata.publisher.managing_organization_name">
-              {{ dataset_metadata.publisher.publisher }}
-            </td>
+      <div v-else class="italic text-gray-500">No publisher</div>
 
-            <td
-              v-if="
-                !dataset_metadata.publisher.publisher &&
-                !dataset_metadata.publisher.managing_organization_name
-              "
-              colspan="2"
-              class="text-center italic text-gray-500"
-            >
-              No Publisher
-            </td>
-          </tr>
-        </tbody>
-      </n-table>
+      <n-h5>Managing Organization Name</n-h5>
+
+      <div
+        v-if="dataset_metadata.publisher && dataset_metadata.publisher.managing_organization_name"
+        class="border border-gray-100 p-3"
+      >
+        {{ dataset_metadata.publisher.managing_organization_name }}
+      </div>
+
+      <div v-else class="italic text-gray-500">No Managing Organization</div>
 
       <template #action>
         <RouterLink
@@ -485,18 +489,27 @@ function handleNextButton() {
     </CollapsibleCard>
 
     <CollapsibleCard title="Subjects" bordered>
-      <n-table
-        :bordered="true"
-        striped
-        :single-line="false"
-        v-if="dataset_metadata.subjects && dataset_metadata.subjects.length"
-      >
-        <tbody>
-          <tr :key="item.id" v-for="item in dataset_metadata.subjects">
-            <td>{{ item.subject }}</td>
-          </tr>
-        </tbody>
-      </n-table>
+      <!--      <n-table-->
+      <!--        :bordered="true"-->
+      <!--        striped-->
+      <!--        :single-line="false"-->
+      <!--        v-if="dataset_metadata.subjects && dataset_metadata.subjects.length"-->
+      <!--      >-->
+      <!--        <tbody>-->
+      <!--          <tr :key="item.id" v-for="item in dataset_metadata.subjects">-->
+      <!--            <td>{{ item.subject }}</td>-->
+      <!--          </tr>-->
+      <!--        </tbody>-->
+      <!--      </n-table>-->
+      <div v-if="dataset_metadata.subjects && dataset_metadata.subjects.length">
+        <ul
+          :key="item.id"
+          class="list-none border border-gray-100 p-3 even:bg-gray-50"
+          v-for="item in dataset_metadata.subjects"
+        >
+          <li>{{ item.subject }}</li>
+        </ul>
+      </div>
 
       <div v-if="!dataset_metadata.subjects.length" class="italic text-gray-500">No Subjects</div>
 

--- a/src/views/study/dataset/publish/metadata/PublishStudyMetadata.vue
+++ b/src/views/study/dataset/publish/metadata/PublishStudyMetadata.vue
@@ -180,6 +180,8 @@ function handleNextButton() {
             <th>Investigator Name</th>
 
             <th>Type</th>
+
+            <th>Sponsor Name</th>
           </tr>
         </thead>
 
@@ -187,16 +189,19 @@ function handleNextButton() {
           <tr
             v-if="
               study_metadata.sponsors.responsible_party_investigator_name &&
-              study_metadata.sponsors.responsible_party_type
+              study_metadata.sponsors.responsible_party_type &&
+              study_metadata.sponsors.lead_sponsor_name
             "
           >
             <td>{{ study_metadata.sponsors.responsible_party_investigator_name }}</td>
 
             <td>{{ study_metadata.sponsors.responsible_party_type }}</td>
+
+            <td>{{ study_metadata.sponsors.lead_sponsor_name }}</td>
           </tr>
 
           <tr v-else>
-            <td colspan="2" class="text-center italic text-gray-500">No Sponsors</td>
+            <td colspan="3" class="text-center italic text-gray-500">No Sponsors</td>
           </tr>
         </tbody>
       </n-table>
@@ -636,21 +641,29 @@ function handleNextButton() {
           <tr>
             <th>Gender</th>
 
+            <th>Gender Based</th>
+
             <th>Minimum Age</th>
           </tr>
         </thead>
 
         <tbody>
           <tr
-            v-if="study_metadata.eligibility.gender && study_metadata.eligibility.maximum_age_value"
+            v-if="
+              study_metadata.eligibility.gender &&
+              study_metadata.eligibility.minimum_age_value &&
+              study_metadata.eligibility.gender_based
+            "
           >
             <td>{{ study_metadata.eligibility.gender }}</td>
 
-            <td>{{ study_metadata.eligibility.maximum_age_value }}</td>
+            <td>{{ study_metadata.eligibility.gender_based }}</td>
+
+            <td>{{ study_metadata.eligibility.minimum_age_value }}</td>
           </tr>
 
           <tr v-else>
-            <td colspan="2" class="text-center italic text-gray-500">No Eligibility</td>
+            <td colspan="3" class="text-center italic text-gray-500">No Eligibility</td>
           </tr>
         </tbody>
       </n-table>
@@ -716,13 +729,15 @@ function handleNextButton() {
       </template>
     </CollapsibleCard>
 
-    <CollapsibleCard title="Overal Officials" bordered>
+    <CollapsibleCard title="Overall Officials" bordered>
       <n-table :bordered="true" :single-line="false" striped>
         <thead>
           <tr>
             <th>Affiliation</th>
 
             <th>Overall Official Name</th>
+
+            <th>Role</th>
           </tr>
         </thead>
 
@@ -731,10 +746,12 @@ function handleNextButton() {
             <td>{{ item.affiliation }}</td>
 
             <td>{{ item.name }}</td>
+
+            <td>{{ item.role }}</td>
           </tr>
 
           <tr v-if="!study_metadata.overall_officials.length">
-            <td colspan="2" class="text-center italic text-gray-500">No Overall Officials</td>
+            <td colspan="3" class="text-center italic text-gray-500">No Overall Officials</td>
           </tr>
         </tbody>
       </n-table>

--- a/src/views/study/metadata/collaborators/StudyCollaborators.vue
+++ b/src/views/study/metadata/collaborators/StudyCollaborators.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import type { FormInst } from "naive-ui";
 
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import { baseURL } from "@/utils/constants";
 
-const router = useRouter();
 const route = useRoute();
 const message = useMessage();
 
@@ -22,9 +22,7 @@ onBeforeMount(async () => {
     throw new Error("Network response was not ok");
   }
 
-  const data = await response.json();
-
-  moduleData.value = data;
+  moduleData.value = await response.json();
 });
 
 const addCollaborator = () => {
@@ -74,7 +72,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Collaborators"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/metadata/collaborators/StudyCollaborators.vue
+++ b/src/views/study/metadata/collaborators/StudyCollaborators.vue
@@ -3,6 +3,7 @@ import type { FormInst } from "naive-ui";
 
 import { baseURL } from "@/utils/constants";
 
+const router = useRouter();
 const route = useRoute();
 const message = useMessage();
 
@@ -73,10 +74,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Collaborators"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      linkName="study:overview"
-      :linkParams="{
-        studyId: route.params.studyId,
-      }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/metadata/conditions/StudyConditions.vue
+++ b/src/views/study/metadata/conditions/StudyConditions.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
 import type { FormInst } from "naive-ui";
-import { useRouter } from "vue-router";
 
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import { baseURL } from "@/utils/constants";
 
-const router = useRouter();
 const route = useRoute();
 const message = useMessage();
 
@@ -74,7 +73,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Conditions"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/metadata/conditions/StudyConditions.vue
+++ b/src/views/study/metadata/conditions/StudyConditions.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import type { FormInst } from "naive-ui";
+import { useRouter } from "vue-router";
 
 import { baseURL } from "@/utils/constants";
 
+const router = useRouter();
 const route = useRoute();
 const message = useMessage();
 
@@ -72,10 +74,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Conditions"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      linkName="study:overview"
-      :linkParams="{
-        studyId: route.params.studyId,
-      }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/metadata/description/StudyDescription.vue
+++ b/src/views/study/metadata/description/StudyDescription.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { FormInst, FormRules } from "naive-ui";
 
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import { baseURL } from "@/utils/constants";
 
 const route = useRoute();
@@ -91,7 +92,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Description"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/metadata/description/StudyDescription.vue
+++ b/src/views/study/metadata/description/StudyDescription.vue
@@ -91,10 +91,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Description"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      linkName="study:overview"
-      :linkParams="{
-        studyId: route.params.studyId,
-      }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/metadata/design/StudyDesign.vue
+++ b/src/views/study/metadata/design/StudyDesign.vue
@@ -249,10 +249,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Design"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      linkName="study:overview"
-      :linkParams="{
-        studyId: route.params.studyId,
-      }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/metadata/design/StudyDesign.vue
+++ b/src/views/study/metadata/design/StudyDesign.vue
@@ -2,6 +2,7 @@
 import type { FormInst, FormRules } from "naive-ui";
 
 import FORM_JSON from "@/assets/data/form.json";
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { StudyDesignModule } from "@/types/Study";
 import { baseURL } from "@/utils/constants";
 
@@ -249,7 +250,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Design"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/metadata/eligibility/StudyEligibility.vue
+++ b/src/views/study/metadata/eligibility/StudyEligibility.vue
@@ -173,10 +173,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Eligibility"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      linkName="study:overview"
-      :linkParams="{
-        studyId: route.params.studyId,
-      }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/metadata/eligibility/StudyEligibility.vue
+++ b/src/views/study/metadata/eligibility/StudyEligibility.vue
@@ -2,6 +2,7 @@
 import type { FormInst, FormRules } from "naive-ui";
 
 import FORM_JSON from "@/assets/data/form.json";
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { StudyEligiblityModule } from "@/types/Study";
 import { baseURL } from "@/utils/constants";
 
@@ -173,7 +174,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Eligibility"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/metadata/enrollment/contacts/StudyContacts.vue
+++ b/src/views/study/metadata/enrollment/contacts/StudyContacts.vue
@@ -2,6 +2,7 @@
 import type { FormInst } from "naive-ui";
 import { nanoid } from "nanoid";
 
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { StudyContacts } from "@/types/Study";
 import { baseURL } from "@/utils/constants";
 
@@ -129,7 +130,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Contacts"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/metadata/enrollment/contacts/StudyContacts.vue
+++ b/src/views/study/metadata/enrollment/contacts/StudyContacts.vue
@@ -129,10 +129,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Contacts"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      linkName="study:overview"
-      :linkParams="{
-        studyId: route.params.studyId,
-      }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/metadata/enrollment/locations/StudyLocations.vue
+++ b/src/views/study/metadata/enrollment/locations/StudyLocations.vue
@@ -4,6 +4,7 @@ import { nanoid } from "nanoid";
 
 import COUNTRIES_JSON from "@/assets/data/countries.json";
 import FORM_JSON from "@/assets/data/form.json";
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { StudyLocations } from "@/types/Study";
 import { baseURL } from "@/utils/constants";
 
@@ -138,7 +139,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Locations"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/metadata/enrollment/locations/StudyLocations.vue
+++ b/src/views/study/metadata/enrollment/locations/StudyLocations.vue
@@ -138,10 +138,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Locations"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      linkName="study:overview"
-      :linkParams="{
-        studyId: route.params.studyId,
-      }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/metadata/enrollment/officials/StudyOfficials.vue
+++ b/src/views/study/metadata/enrollment/officials/StudyOfficials.vue
@@ -125,10 +125,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Overall Officials"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      linkName="study:overview"
-      :linkParams="{
-        studyId: route.params.studyId,
-      }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/metadata/enrollment/officials/StudyOfficials.vue
+++ b/src/views/study/metadata/enrollment/officials/StudyOfficials.vue
@@ -3,6 +3,7 @@ import type { FormInst } from "naive-ui";
 import { nanoid } from "nanoid";
 
 import FORM_JSON from "@/assets/data/form.json";
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { StudyOverallOfficials } from "@/types/Study";
 import { baseURL } from "@/utils/constants";
 
@@ -125,7 +126,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Overall Officials"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/metadata/identification/StudyIdentification.vue
+++ b/src/views/study/metadata/identification/StudyIdentification.vue
@@ -159,10 +159,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Identification"
       description="Identifiers for the study"
-      linkName="study:overview"
-      :linkParams="{
-        studyId: route.params.studyId,
-      }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/metadata/identification/StudyIdentification.vue
+++ b/src/views/study/metadata/identification/StudyIdentification.vue
@@ -3,6 +3,7 @@ import type { FormInst, FormRules } from "naive-ui";
 import { nanoid } from "nanoid";
 
 import FORM_JSON from "@/assets/data/form.json";
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { StudyIdentificationModule } from "@/types/Study";
 import { baseURL } from "@/utils/constants";
 
@@ -159,7 +160,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Identification"
       description="Identifiers for the study"
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/metadata/ipdsharing/StudyIPDSharing.vue
+++ b/src/views/study/metadata/ipdsharing/StudyIPDSharing.vue
@@ -94,10 +94,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="IPD Sharing"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      linkName="study:overview"
-      :linkParams="{
-        studyId: route.params.studyId,
-      }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/metadata/ipdsharing/StudyIPDSharing.vue
+++ b/src/views/study/metadata/ipdsharing/StudyIPDSharing.vue
@@ -2,6 +2,7 @@
 import type { FormInst, FormRules } from "naive-ui";
 
 import FORM_JSON from "@/assets/data/form.json";
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { StudyIPDSharing } from "@/types/Study";
 import { baseURL } from "@/utils/constants";
 
@@ -94,7 +95,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="IPD Sharing"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/metadata/oversight/StudyOversight.vue
+++ b/src/views/study/metadata/oversight/StudyOversight.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
-import { useRouter } from "vue-router";
-
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import { baseURL } from "@/utils/constants";
 
-const router = useRouter();
 const route = useRoute();
 const message = useMessage();
 
@@ -54,7 +52,8 @@ const saveMetadata = async (value: boolean) => {
     <PageBackNavigationHeader
       title="Oversight"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/metadata/oversight/StudyOversight.vue
+++ b/src/views/study/metadata/oversight/StudyOversight.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
+import { useRouter } from "vue-router";
+
 import { baseURL } from "@/utils/constants";
 
+const router = useRouter();
 const route = useRoute();
 const message = useMessage();
 
@@ -51,10 +54,7 @@ const saveMetadata = async (value: boolean) => {
     <PageBackNavigationHeader
       title="Oversight"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      linkName="study:overview"
-      :linkParams="{
-        studyId: route.params.studyId,
-      }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/metadata/references/availableipd/StudyAvailableIPD.vue
+++ b/src/views/study/metadata/references/availableipd/StudyAvailableIPD.vue
@@ -4,6 +4,7 @@ import { nanoid } from "nanoid";
 
 import FORM_JSON from "@/assets/data/form.json";
 import CollapsibleCard from "@/components/cards/CollapsibleCard.vue";
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { StudyIPDs } from "@/types/Study";
 import { baseURL } from "@/utils/constants";
 
@@ -127,7 +128,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Available IPD"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/metadata/references/availableipd/StudyAvailableIPD.vue
+++ b/src/views/study/metadata/references/availableipd/StudyAvailableIPD.vue
@@ -127,10 +127,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Available IPD"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      linkName="study:overview"
-      :linkParams="{
-        studyId: route.params.studyId,
-      }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/metadata/references/links/StudyLinks.vue
+++ b/src/views/study/metadata/references/links/StudyLinks.vue
@@ -2,6 +2,7 @@
 import type { FormInst } from "naive-ui";
 import { nanoid } from "nanoid";
 
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { StudyLinks } from "@/types/Study";
 import { baseURL } from "@/utils/constants";
 
@@ -117,7 +118,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Links"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/metadata/references/links/StudyLinks.vue
+++ b/src/views/study/metadata/references/links/StudyLinks.vue
@@ -117,10 +117,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Links"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      linkName="study:overview"
-      :linkParams="{
-        studyId: route.params.studyId,
-      }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/metadata/references/publications/StudyReferences.vue
+++ b/src/views/study/metadata/references/publications/StudyReferences.vue
@@ -121,10 +121,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Publications"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      linkName="study:overview"
-      :linkParams="{
-        studyId: route.params.studyId,
-      }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/metadata/references/publications/StudyReferences.vue
+++ b/src/views/study/metadata/references/publications/StudyReferences.vue
@@ -3,6 +3,7 @@ import type { FormInst } from "naive-ui";
 import { nanoid } from "nanoid";
 
 import FORM_JSON from "@/assets/data/form.json";
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { StudyReferences } from "@/types/Study";
 import { baseURL } from "@/utils/constants";
 
@@ -121,7 +122,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Publications"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/metadata/sponsors/StudySponsors.vue
+++ b/src/views/study/metadata/sponsors/StudySponsors.vue
@@ -99,10 +99,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Sponsors"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      linkName="study:overview"
-      :linkParams="{
-        studyId: route.params.studyId,
-      }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/metadata/sponsors/StudySponsors.vue
+++ b/src/views/study/metadata/sponsors/StudySponsors.vue
@@ -2,6 +2,7 @@
 import type { FormInst, FormRules } from "naive-ui";
 
 import FORM_JSON from "@/assets/data/form.json";
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { StudySponsorCollaboratorsModule } from "@/types/Study";
 import { baseURL } from "@/utils/constants";
 
@@ -99,7 +100,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Sponsors"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/metadata/status/StudyStatus.vue
+++ b/src/views/study/metadata/status/StudyStatus.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import dayjs from "dayjs";
 import type { FormInst, FormRules } from "naive-ui";
+import { useRouter } from "vue-router";
 
 import FORM_JSON from "@/assets/data/form.json";
 import type { StudyStatusModule } from "@/types/Study";
 import { baseURL } from "@/utils/constants";
-
+const router = useRouter();
 const route = useRoute();
 const push = usePush();
 
@@ -118,10 +119,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Status"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      linkName="study:overview"
-      :linkParams="{
-        studyId: route.params.studyId,
-      }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/metadata/status/StudyStatus.vue
+++ b/src/views/study/metadata/status/StudyStatus.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
 import dayjs from "dayjs";
 import type { FormInst, FormRules } from "naive-ui";
-import { useRouter } from "vue-router";
 
 import FORM_JSON from "@/assets/data/form.json";
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { StudyStatusModule } from "@/types/Study";
 import { baseURL } from "@/utils/constants";
-const router = useRouter();
 const route = useRoute();
 const push = usePush();
 
@@ -119,7 +118,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Status"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/metadata/treatment/arms/StudyArms.vue
+++ b/src/views/study/metadata/treatment/arms/StudyArms.vue
@@ -132,10 +132,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Arms"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      linkName="study:overview"
-      :linkParams="{
-        studyId: route.params.studyId,
-      }"
+      @click="router.go(-1)"
     />
 
     <n-divider />

--- a/src/views/study/metadata/treatment/arms/StudyArms.vue
+++ b/src/views/study/metadata/treatment/arms/StudyArms.vue
@@ -3,6 +3,7 @@ import type { FormInst } from "naive-ui";
 import { nanoid } from "nanoid";
 
 import FORM_JSON from "@/assets/data/form.json";
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { StudyArms } from "@/types/Study";
 import { baseURL } from "@/utils/constants";
 
@@ -132,7 +133,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Arms"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/metadata/treatment/interventions/StudyInterventions.vue
+++ b/src/views/study/metadata/treatment/interventions/StudyInterventions.vue
@@ -3,6 +3,7 @@ import type { FormInst } from "naive-ui";
 import { nanoid } from "nanoid";
 
 import FORM_JSON from "@/assets/data/form.json";
+import { getBackParams, getBackRoute } from "@/stores/nav";
 import type { StudyInterventions } from "@/types/Study";
 import { baseURL } from "@/utils/constants";
 
@@ -148,7 +149,8 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Interventions"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      @click="router.go(-1)"
+      :linkName="getBackRoute()"
+      :linkParams="getBackParams()"
     />
 
     <n-divider />

--- a/src/views/study/metadata/treatment/interventions/StudyInterventions.vue
+++ b/src/views/study/metadata/treatment/interventions/StudyInterventions.vue
@@ -148,10 +148,7 @@ const saveMetadata = (e: MouseEvent) => {
     <PageBackNavigationHeader
       title="Interventions"
       description="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quisquam quod quia voluptatibus, voluptatem, quibusdam, quos voluptas quae quas voluptatum"
-      linkName="study:overview"
-      :linkParams="{
-        studyId: route.params.studyId,
-      }"
+      @click="router.go(-1)"
     />
 
     <n-divider />


### PR DESCRIPTION
- Fixed navigating back buttons in the study and dataset metadata (on a version page previous button brings user back to the version steps);
- Trivial style fix in the minimized version step pages 
- Added few deleted study metadata props in the version steps